### PR TITLE
refactor: Refactor code to be more idiomatic.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pufferpanel-conditions",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pufferpanel-conditions",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache v2",
       "devDependencies": {
         "wasm-pack": "^0.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pufferpanel-conditions",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "PufferPanel 'if' processor for frontend usage",
   "license": "Apache v2",
   "scripts": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate console_error_panic_hook;
+use rhai::packages::BasicArrayPackage;
+use rhai::packages::{CorePackage, Package};
 use rhai::{Engine, Scope};
 use wasm_bindgen::prelude::*;
-use rhai::packages::{CorePackage, Package};
-use rhai::packages::BasicArrayPackage;
 
 #[wasm_bindgen]
 pub fn resolve_if(script: &str, data: &JsValue) -> Result<bool, String> {
@@ -17,26 +17,19 @@ pub fn resolve_if(script: &str, data: &JsValue) -> Result<bool, String> {
 
     let mut scope = Scope::new();
 
-    let keys = match js_sys::Reflect::own_keys(data) {
-        Ok(res) => res,
-        Err(e) => return Err(e.as_string().unwrap())
-    };
+    let keys = js_sys::Reflect::own_keys(data).map_err(js_value_to_string)?;
 
     let mut vars = rhai::Map::new();
 
     for key in keys {
-        let value = match js_sys::Reflect::get(data, &key) {
-            Ok(res) => res,
-            Err(e) => return Err(e.as_string().unwrap())
-        };
-
-        let k = key.as_string().unwrap().to_owned();
-        if value.as_bool().is_some() {
-            vars.insert(k.into(), value.as_bool().unwrap().into());
-        } else if value.as_f64().is_some() {
-            vars.insert(k.into(), value.as_f64().unwrap().into());
-        } else if value.as_string().is_some() {
-            vars.insert(k.into(), value.as_string().unwrap().into());
+        let value = js_sys::Reflect::get(data, &key).map_err(js_value_to_string)?;
+        let k = key.as_string().unwrap().into();
+        if let Some(value) = value.as_bool() {
+            vars.insert(k, value.into());
+        } else if let Some(value) = value.as_f64() {
+            vars.insert(k, value.into());
+        } else if let Some(value) = value.as_string() {
+            vars.insert(k, value.into());
         }
     }
 
@@ -44,9 +37,11 @@ pub fn resolve_if(script: &str, data: &JsValue) -> Result<bool, String> {
 
     let altered = script.replace("'", "\"");
 
-    let result = match engine.eval_expression_with_scope::<bool>(&mut scope, &altered) {
-        Ok(res) => res,
-        Err(e) => return Err(e.to_string())
-    };
-    Ok(result)
+    engine
+        .eval_expression_with_scope::<bool>(&mut scope, &altered)
+        .map_err(|e| e.to_string())
+}
+
+fn js_value_to_string(value: JsValue) -> String{
+    value.as_string().unwrap()
 }


### PR DESCRIPTION
The type conversion isn't as readable as it relied on repeated explicit conversions; we can make use of implicit types to remove the need for the former. This also makes use of pattern matching to combine the "as_foo" & "is_foo" steps.

Hopefully, javascript equivalency rules don't cause pain.

Error handling was also overly verbose, those have been replaced with tider `map_err`/free function versions.